### PR TITLE
Add Supabase functionality

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-publishable-key

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env.local
 
 # vercel
 .vercel

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -2,40 +2,28 @@
 
 ## Step 1: Create a Supabase Account and Project
 
-1. Go to [https://supabase.com](https://supabase.com) and sign up for a free account
+1. Go to [https://supabase.com](https://supabase.com) and sign up.
 2. Click **New Project**
-3. Choose a name (e.g. `cs464-dev`), a strong database password, and any region
-
----
+3. Choose a name (e.g. `cs464-dev`) and database password.
 
 ## Step 2: Create the Database Schema
 
 1. In your Supabase project dashboard, click **SQL Editor** in the left sidebar
-2. Click **New query**
-3. Copy the entire contents of [`supabase/schema.sql`](../supabase/schema.sql) and paste it into the editor
-4. Click **Run**
-5. It should say "Success, no rows returned".
-
----
+2. Copy the entire contents of [`supabase/schema.sql`](../supabase/schema.sql) and paste it into the editor
+3. Click **Run**
+4. It should say "Success, no rows returned".
 
 ## Step 3: Seed the Database
 
-1. In the SQL Editor, open another **New query**
+1. In the SQL Editor, open a **New query**
 2. Copy the entire contents of [`supabase/seed.sql`](../supabase/seed.sql) and paste it into the editor
 3. Click **Run**
 4. It should say "Success, no rows returned".
 
----
-
 ## Step 4: Get Your Project Credentials
 
-1. In the Supabase dashboard, you should see a **link** you can cop underneath the title, copy that.
-1. In the Supabase dashboard, click the **gear icon** (Settings) in the left sidebar
-1. Click **API** under the Configuration section
-1. Copy two values:
-   - **Project API keys → Publishble Key**
-
----
+1. In the Supabase dashboard, you should see a **link** you can cop underneath the title, click the copy button.
+2. Within that dropdown you will see your **Project URL** and **Publishable Key** needed for `.env.local`.
 
 ## Step 5: Configure Your Local Environment
 
@@ -46,8 +34,6 @@
    NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
    ```
-
----
 
 ## Step 6: Run the App
 

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -1,0 +1,58 @@
+# Supabase Setup for Contributors
+
+## Step 1: Create a Supabase Account and Project
+
+1. Go to [https://supabase.com](https://supabase.com) and sign up for a free account
+2. Click **New Project**
+3. Choose a name (e.g. `cs464-dev`), a strong database password, and any region
+
+---
+
+## Step 2: Create the Database Schema
+
+1. In your Supabase project dashboard, click **SQL Editor** in the left sidebar
+2. Click **New query**
+3. Copy the entire contents of [`supabase/schema.sql`](../supabase/schema.sql) and paste it into the editor
+4. Click **Run**
+5. It should say "Success, no rows returned".
+
+---
+
+## Step 3: Seed the Database
+
+1. In the SQL Editor, open another **New query**
+2. Copy the entire contents of [`supabase/seed.sql`](../supabase/seed.sql) and paste it into the editor
+3. Click **Run**
+4. It should say "Success, no rows returned".
+
+---
+
+## Step 4: Get Your Project Credentials
+
+1. In the Supabase dashboard, you should see a **link** you can cop underneath the title, copy that.
+1. In the Supabase dashboard, click the **gear icon** (Settings) in the left sidebar
+1. Click **API** under the Configuration section
+1. Copy two values:
+   - **Project API keys → Publishble Key**
+
+---
+
+## Step 5: Configure Your Local Environment
+
+1. In the root of the project, copy the `.env.local.exaxmple` and paste as `env.local`.
+2. Open `.env.local` and fill in your values:
+
+   ```
+   NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+   ```
+
+---
+
+## Step 6: Run the App
+
+```bash
+npm run dev
+```
+
+The app will now fetch datasets from your personal Supabase project instead of local JSON files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
+        "@supabase/supabase-js": "^2.103.2",
         "next": "^16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -55,7 +56,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -362,7 +362,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -406,7 +405,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1201,7 +1199,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.0.tgz",
       "integrity": "sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@mui/core-downloads-tracker": "^9.0.0",
@@ -1628,6 +1625,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.103.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.2.tgz",
+      "integrity": "sha512-gHCp8J7TJ3ZrNsT5NiJt8Sa5SK7QnotUtxkBEaJ/vuimZ6MsWn6p4JWoDc01uZBmJTiISH3gQqTF2/S+kglDIw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.103.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.2.tgz",
+      "integrity": "sha512-VescBNuZPVcoFpH3R44YbLDDFPZnMtzBHuY1cNyL75h8Vlw9YBHv9qztVgDalKRoeA9wNQhuHqawXdTgCobhIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.103.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.2.tgz",
+      "integrity": "sha512-Qi9Dn0azoI/RhaVnZsggeQg6MY+7jg3jHVPt2vlh9nojMjOBniTbBeSrdSSEdufpbwXxPne3Z13OPva1VmC9CA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.103.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.2.tgz",
+      "integrity": "sha512-zj/JruFaSJScdtq0W2cI+WbLuQmwYBD8i++0YFlzwyAeeZy9RwEAfjT1mkvhBNHPCy2V4LIsE4F0rAHSGR8AOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.103.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.2.tgz",
+      "integrity": "sha512-d40lZ29EyWJ4cOTtSBH4myaRuYSa9kOdt+NFkUmR+a3SAy2VpbdI1/nE3QWIrdifOa4pxTo8RXGC3BngPMVhRw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.103.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.2.tgz",
+      "integrity": "sha512-GlC5me7/WlyS1ZCpwLoCm7ezggRWxyMxfckDhtnJvGanoVZAOnCKSqrNkjmDF8aufdh/kOoXRc/P3zJ/eUKMTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.103.2",
+        "@supabase/functions-js": "2.103.2",
+        "@supabase/postgrest-js": "2.103.2",
+        "@supabase/realtime-js": "2.103.2",
+        "@supabase/storage-js": "2.103.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1673,7 +1756,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1696,7 +1778,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1718,6 +1799,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1765,7 +1855,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2291,7 +2380,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2650,7 +2738,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3245,7 +3332,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3431,7 +3517,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4121,6 +4206,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -5360,7 +5454,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5370,7 +5463,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6065,7 +6157,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6228,7 +6319,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6284,7 +6374,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6478,6 +6567,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -6513,7 +6623,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
+    "@supabase/supabase-js": "^2.103.2",
     "next": "^16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -4,6 +4,7 @@ import { DataFile, DataItem } from '@/types/data'
 type ItemRow = { name: string; order_index: number }
 type DatasetRow = { name: string; title: string; description: string; dataset_items: ItemRow[] }
 
+// convert a dataset row into a DataFile object
 function toDataFile(row: DatasetRow): DataFile {
     return {
         title: row.title,
@@ -18,6 +19,7 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url)
     const name = searchParams.get('name')
 
+    // check if dataset is in database.
     if (name) {
         const { data, error } = await supabase
             .from('datasets')
@@ -32,6 +34,7 @@ export async function GET(request: Request) {
         return Response.json(toDataFile(data as DatasetRow))
     }
 
+    // error checking 
     const { data, error } = await supabase
         .from('datasets')
         .select('name, title, description, dataset_items(name, order_index)')
@@ -40,6 +43,7 @@ export async function GET(request: Request) {
         return Response.json({ error: 'Failed to fetch datasets' }, { status: 500 })
     }
 
+    //append all datasets into a single object
     const allData: Record<string, DataFile> = {}
     for (const row of data as DatasetRow[]) {
         allData[row.name] = toDataFile(row)

--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -1,36 +1,49 @@
-import path from 'path'
-import fs from 'fs/promises'
-import { DataFile } from '@/types/data'
+import { supabase } from '@/lib/supabase'
+import { DataFile, DataItem } from '@/types/data'
 
+type ItemRow = { name: string; order_index: number }
+type DatasetRow = { name: string; title: string; description: string; dataset_items: ItemRow[] }
 
-const dataDirectory = path.join(process.cwd(), "data")
+function toDataFile(row: DatasetRow): DataFile {
+    return {
+        title: row.title,
+        description: row.description,
+        items: row.dataset_items
+            .sort((a, b) => a.order_index - b.order_index)
+            .map((item): DataItem => ({ name: item.name, order: item.order_index })),
+    }
+}
 
 export async function GET(request: Request) {
     const { searchParams } = new URL(request.url)
     const name = searchParams.get('name')
 
-    // query param containing name -> return specified file
     if (name) {
-        const filePath = path.join(dataDirectory, `${name}.json`)
-        try {
-            const content = await fs.readFile(filePath, 'utf-8')
-            return Response.json(JSON.parse(content))
-        } catch {
+        const { data, error } = await supabase
+            .from('datasets')
+            .select('name, title, description, dataset_items(name, order_index)')
+            .eq('name', name)
+            .single()
+
+        if (error || !data) {
             return Response.json({ error: `No dataset found for ${name}` }, { status: 404 })
         }
-    } 
 
-    // no query param
-
-    // get files
-    const files = (await fs.readdir(dataDirectory)).filter(f => f.endsWith('.json'))
-    const allData: Record<string, DataFile> = {}
-
-    // iterate through json files in dataDirectory 
-    for (const file of files){
-        const filePath = path.join(dataDirectory, file)
-        const content = await fs.readFile(filePath, 'utf-8')
-        allData[file.replace('.json', '')] = JSON.parse(content)
+        return Response.json(toDataFile(data as DatasetRow))
     }
-    return Response.json({datasets: allData})
+
+    const { data, error } = await supabase
+        .from('datasets')
+        .select('name, title, description, dataset_items(name, order_index)')
+
+    if (error || !data) {
+        return Response.json({ error: 'Failed to fetch datasets' }, { status: 500 })
+    }
+
+    const allData: Record<string, DataFile> = {}
+    for (const row of data as DatasetRow[]) {
+        allData[row.name] = toDataFile(row)
+    }
+
+    return Response.json({ datasets: allData })
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,23 @@
+-- CS464 Database Schema
+-- Run this in the Supabase SQL editor before running seed.sql
+
+CREATE TABLE IF NOT EXISTS datasets (
+    id          SERIAL PRIMARY KEY,
+    name        TEXT UNIQUE NOT NULL,  -- slug used as API query param (e.g. 'planets')
+    title       TEXT NOT NULL,
+    description TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS dataset_items (
+    id          SERIAL PRIMARY KEY,
+    dataset_id  INTEGER NOT NULL REFERENCES datasets(id) ON DELETE CASCADE,
+    name        TEXT    NOT NULL,
+    order_index INTEGER NOT NULL
+);
+
+-- allow public read, deny all writes from anon key
+ALTER TABLE datasets      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dataset_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public read" ON datasets      FOR SELECT USING (true);
+CREATE POLICY "public read" ON dataset_items FOR SELECT USING (true);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,712 @@
+-- CS464 Seed Data
+-- Run this in the Supabase SQL editor AFTER running schema.sql
+-- This inserts all the JSON data we have currently
+
+-- bh_legends
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('bh_legends', 'Brawlhalla Legends', 'Put the legends in order by chronological order they were added to the Game')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Bodvar', 1),
+    ('Cassidy', 2),
+    ('Orion', 3),
+    ('Lord Vraxx', 4),
+    ('Gnash', 5),
+    ('Queen Nai', 6),
+    ('Hattori', 7),
+    ('Sir Roland', 8),
+    ('Scarlet', 9),
+    ('Thatch', 10),
+    ('Ada', 11),
+    ('Sentinel', 12),
+    ('Lucien', 13),
+    ('Teros', 14),
+    ('Brynn', 15),
+    ('Asuri', 16),
+    ('Barraza', 17),
+    ('Ember', 18),
+    ('Azoth', 19),
+    ('Koji', 20),
+    ('Ulgrim', 21),
+    ('Diana', 22),
+    ('Jhala', 23),
+    ('Kor', 24),
+    ('Wu Shang', 25),
+    ('Val', 26),
+    ('Ragnir', 27),
+    ('Cross', 28),
+    ('Mirage', 29),
+    ('Nix', 30),
+    ('Mordex', 31),
+    ('Yumiko', 32),
+    ('Artemis', 33),
+    ('Caspian', 34),
+    ('Sidra', 35),
+    ('Xull', 36),
+    ('Kaya', 37),
+    ('Isaiah', 38),
+    ('Jiro', 39),
+    ('Lin Fei', 40),
+    ('Zariel', 41),
+    ('Rayman', 42),
+    ('Dusk', 43),
+    ('Fait', 44),
+    ('Thor', 45),
+    ('Petra', 46),
+    ('Vector', 47),
+    ('Volkov', 48),
+    ('Onyx', 49),
+    ('Jaeyun', 50),
+    ('Mako', 51),
+    ('Magyar', 52),
+    ('Reno', 53),
+    ('Munin', 54),
+    ('Arcadia', 55),
+    ('Ezio', 56),
+    ('Tezca', 57),
+    ('Thea', 58),
+    ('Red Raptor', 59),
+    ('Loki', 60),
+    ('Seven', 61),
+    ('Vivi', 62),
+    ('Imugi', 63),
+    ('King Zuva', 64),
+    ('Priya', 65),
+    ('Ransom', 66),
+    ('Lady Vera', 67),
+    ('Rupture', 68)
+) AS v(name, order_index);
+
+-- bird_population
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('bird_population', 'Bird Populations', 'Put the birds in order by population (most common first).')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('House Sparrow', 1),
+    ('European Starling', 2),
+    ('Rock Pigeon', 3),
+    ('Barn Swallow', 4),
+    ('Red-billed Quelea', 5),
+    ('Common Grackle', 6),
+    ('American Robin', 7),
+    ('Red-winged Blackbird', 8),
+    ('Yellow-rumped Warbler', 9),
+    ('Common Blackbird', 10),
+    ('White Wagtail', 11),
+    ('Song Sparrow', 12),
+    ('Brown-headed Cowbird', 13),
+    ('Canada Goose', 14),
+    ('Mallard', 15),
+    ('Great-tailed Grackle', 16),
+    ('House Finch', 17),
+    ('Northern Cardinal', 18),
+    ('American Crow', 19),
+    ('Black-capped Chickadee', 20),
+    ('European Goldfinch', 21),
+    ('Cliff Swallow', 22),
+    ('Tree Sparrow', 23),
+    ('Zebra Finch', 24),
+    ('Common Waxbill', 25)
+) AS v(name, order_index);
+
+-- console_release
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('console_release', 'Game Consoles', 'Put the game consoles in order by release year (earliest first).')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Magnavox Odyssey', 1),
+    ('Magnavox Odyssey 100', 2),
+    ('Magnavox Odyssey 200', 3),
+    ('Magnavox Odyssey 300', 4),
+    ('Magnavox Odyssey 400', 5),
+    ('Magnavox Odyssey 500', 6),
+    ('Magnavox Odyssey 2000', 7),
+    ('Magnavox Odyssey 3000', 8),
+    ('Magnavox Odyssey 4000', 9),
+    ('Atari Pong (Home Pong)', 10),
+    ('Coleco Telstar', 11),
+    ('Fairchild Channel F', 12),
+    ('Atari 2600', 13),
+    ('Magnavox Odyssey²', 14),
+    ('Intellivision', 15),
+    ('ColecoVision', 16),
+    ('Atari 5200', 17),
+    ('Nintendo Entertainment System (NES)', 18),
+    ('Sega Master System', 19),
+    ('Atari 7800', 20),
+    ('TurboGrafx-16 (PC Engine)', 21),
+    ('Sega Genesis (Mega Drive)', 22),
+    ('Sega CD', 23),
+    ('Philips CD-i', 24),
+    ('Neo Geo AES', 25),
+    ('Super Nintendo Entertainment System (SNES)', 26),
+    ('3DO Interactive Multiplayer', 27),
+    ('Atari Jaguar', 28),
+    ('Amiga CD32', 29),
+    ('Sega 32X', 30),
+    ('Sega Saturn', 31),
+    ('PlayStation', 32),
+    ('Nintendo 64', 33),
+    ('Nuon', 34),
+    ('Dreamcast', 35),
+    ('PlayStation 2', 36),
+    ('GameCube', 37),
+    ('Xbox', 38),
+    ('Gizmondo', 39),
+    ('Xbox 360', 40),
+    ('PlayStation 3', 41),
+    ('Wii', 42),
+    ('Wii U', 43),
+    ('OUYA', 44),
+    ('PlayStation 4', 45),
+    ('Xbox One', 46),
+    ('Xbox One S', 47),
+    ('PlayStation 4 Pro', 48),
+    ('Xbox One X', 49),
+    ('Valve Steam Machine (Platform)', 50),
+    ('NES Classic Edition (NES Mini)', 51),
+    ('SNES Classic Edition', 52),
+    ('PlayStation Classic', 53),
+    ('Sega Genesis Mini', 54),
+    ('TurboGrafx-16 Mini', 55),
+    ('Sega Genesis Mini 2', 56),
+    ('Atari VCS (2021)', 57),
+    ('Nintendo Switch', 58),
+    ('PlayStation 5', 59),
+    ('PlayStation 5 Pro', 60),
+    ('Xbox Series X/S', 61),
+    ('(NEW) Steam Machine', 62)
+) AS v(name, order_index);
+
+-- countries_area
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('countries_area', '20 Largest Countries by Land Area', 'Put these countries in order by total land area (largest first).')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Russia', 1),
+    ('Canada', 2),
+    ('United States', 3),
+    ('China', 4),
+    ('Brazil', 5),
+    ('Australia', 6),
+    ('India', 7),
+    ('Argentina', 8),
+    ('Kazakhstan', 9),
+    ('Algeria', 10),
+    ('DR Congo', 11),
+    ('Saudi Arabia', 12),
+    ('Mexico', 13),
+    ('Indonesia', 14),
+    ('Sudan', 15),
+    ('Libya', 16),
+    ('Iran', 17),
+    ('Mongolia', 18),
+    ('Peru', 19),
+    ('Chad', 20)
+) AS v(name, order_index);
+
+-- dragon_quest
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('dragon_quest', 'Dragon Quest Series', 'Put the games in order by in-world chronology, not release date.')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Dragon Quest 11', 1),
+    ('Dragon Quest 3', 2),
+    ('Dragon Quest', 3),
+    ('Dragon Quest 2', 4),
+    ('Dragon Quest 6', 5),
+    ('Dragon Quest 4', 6),
+    ('Dragon Quest 5', 7),
+    ('Dragon Quest 7', 8),
+    ('Dragon Quest 8', 9),
+    ('Dragon Quest 9', 10),
+    ('Dragon Quest 10', 11)
+) AS v(name, order_index);
+
+-- fish
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('fish', 'Fish', 'Fish in Central Oregon ordered by average length.')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Brook Stickleback', 1),
+    ('Speckled Dace', 2),
+    ('Fathead Minnow', 3),
+    ('Longnose Dace', 4),
+    ('Pumpkinseed Sunfish', 5),
+    ('Bluegill', 6),
+    ('Yellow Perch', 7),
+    ('Chiselmouth', 8),
+    ('Tui Chub', 9),
+    ('Peamouth', 10),
+    ('Brown Bullhead', 11),
+    ('Black Crappie', 12),
+    ('White Crappie', 13),
+    ('Brook Trout', 14),
+    ('Mountain Whitefish', 15),
+    ('Kokanee Salmon', 16),
+    ('Redband Trout', 17),
+    ('Smallmouth Bass', 18),
+    ('Rainbow Trout', 19),
+    ('Largemouth Bass', 20),
+    ('Walleye', 21),
+    ('Brown Trout', 22),
+    ('Common Carp', 23),
+    ('Lake Whitefish', 24),
+    ('Channel Catfish', 25),
+    ('Bull Trout', 26),
+    ('Coho Salmon', 27),
+    ('Lake Trout', 28),
+    ('Steelhead', 29),
+    ('Chinook Salmon', 30)
+) AS v(name, order_index);
+
+-- moon_missions
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('moon_missions', 'Moon Missions', 'Put the moon missions in order by oldest to the newest.')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Pioneer 0', 1),
+    ('Luna E-1 No.1', 2),
+    ('Pioneer 1', 3),
+    ('Luna E-1 No.2', 4),
+    ('Pioneer 2', 5),
+    ('Luna E-1 No.3', 6),
+    ('Pioneer 3', 7),
+    ('Luna 1', 8),
+    ('Pioneer 4', 9),
+    ('E-1A No.1', 10),
+    ('Luna 2', 11),
+    ('Luna 3', 12),
+    ('Pioneer P-3', 13),
+    ('Luna E-3 No.1', 14),
+    ('Luna E-3 No.2', 15),
+    ('Pioneer P-30', 16),
+    ('Pioneer P-31', 17),
+    ('Ranger 3', 18),
+    ('Ranger 4', 19),
+    ('Ranger 5', 20),
+    ('Luna E-6 No.2', 21),
+    ('Luna E-6 No.3', 22),
+    ('Luna 4', 23),
+    ('Ranger 6', 24),
+    ('Luna E-6 No.6', 25),
+    ('Luna E-6 No.5', 26),
+    ('Ranger 7', 27),
+    ('Ranger 8', 28),
+    ('Kosmos 60', 29),
+    ('Ranger 9', 30),
+    ('Luna E-6 No.8', 31),
+    ('Luna 5', 32),
+    ('Luna 6', 33),
+    ('Zond 3', 34),
+    ('Luna 7', 35),
+    ('Luna 8', 36),
+    ('Luna 9', 37),
+    ('Kosmos 111', 38),
+    ('Luna 10', 39),
+    ('Surveyor 1', 40),
+    ('Explorer 33', 41),
+    ('Lunar Orbiter 1', 42),
+    ('Luna 11', 43),
+    ('Surveyor 2', 44),
+    ('Luna 12', 45),
+    ('Lunar Orbiter 2', 46),
+    ('Luna 13', 47),
+    ('Lunar Orbiter 3', 48),
+    ('Surveyor 3', 49),
+    ('Lunar Orbiter 4', 50),
+    ('Surveyor 4', 51),
+    ('Explorer 35', 52),
+    ('Lunar Orbiter 5', 53),
+    ('Surveyor 5', 54),
+    ('Soyuz 7K-L1 No.4L', 55),
+    ('Surveyor 6', 56),
+    ('Soyuz 7K-L1 No.5L', 57),
+    ('Surveyor 7', 58),
+    ('Luna E-6LS No.112', 59),
+    ('Luna 14', 60),
+    ('Soyuz 7K-L1 No.7L', 61),
+    ('Zond 5', 62),
+    ('Zond 6', 63),
+    ('Apollo 8', 64),
+    ('Soyuz 7K-L1 No.13L', 65),
+    ('Luna E-8 No.201', 66),
+    ('Soyuz 7K-L1S No.3', 67),
+    ('Apollo 10', 68),
+    ('Luna E-8-5 No.402', 69),
+    ('Soyuz 7K-L1S No.5', 70),
+    ('Luna 15', 71),
+    ('Apollo 11', 72),
+    ('Zond 7', 73),
+    ('Kosmos 300', 74),
+    ('Kosmos 305', 75),
+    ('Apollo 12', 76),
+    ('Luna E-8-5 No.405', 77),
+    ('Apollo 13', 78),
+    ('Luna 16', 79),
+    ('Zond 8', 80),
+    ('Luna 17', 81),
+    ('Apollo 14', 82),
+    ('Apollo 15', 83),
+    ('PFS-1', 84),
+    ('Luna 18', 85),
+    ('Luna 19', 86),
+    ('Luna 20', 87),
+    ('Apollo 16', 88),
+    ('PFS-2', 89),
+    ('Soyuz 7K-LOK No.1', 90),
+    ('Apollo 17', 91),
+    ('Luna 21', 92),
+    ('Explorer 49', 93),
+    ('Mariner 10', 94),
+    ('Luna 22', 95),
+    ('Luna 23', 96),
+    ('Luna E-8-5M No.412', 97),
+    ('Luna 24', 98),
+    ('ISEE-3', 99),
+    ('Hiten', 100),
+    ('Geotail', 101),
+    ('WIND', 102),
+    ('Clementine', 103),
+    ('HGS-1', 104),
+    ('Lunar Prospector', 105),
+    ('Nozomi', 106),
+    ('WMAP', 107),
+    ('SMART-1', 108),
+    ('STEREO', 109),
+    ('ARTEMIS', 110),
+    ('SELENE', 111),
+    ('Chang''e 1', 112),
+    ('Chandrayaan-1', 113),
+    ('LRO & LCROSS', 114),
+    ('Chang''e 2', 115),
+    ('GRAIL', 116),
+    ('LADEE', 117),
+    ('Chang''e 3', 118),
+    ('Chang''e 5-T1', 119),
+    ('TESS', 120),
+    ('Queqiao', 121),
+    ('Chang''e 4', 122),
+    ('Beresheet', 123),
+    ('Chandrayaan-2', 124),
+    ('Chang''e 5', 125),
+    ('CAPSTONE', 126),
+    ('Danuri', 127),
+    ('Artemis I', 128),
+    ('Hakuto-R Mission 1', 129),
+    ('Jupiter Icy Moons Explorer', 130),
+    ('Chandrayaan-3', 131),
+    ('Luna 25', 132),
+    ('SLIM', 133),
+    ('Peregrine Mission One', 134),
+    ('IM-1', 135),
+    ('DRO A/B', 136),
+    ('Queqiao-2', 137),
+    ('Chang''e 6', 138),
+    ('Blue Ghost M1', 139),
+    ('Hakuto-R Mission 2', 140),
+    ('Lunar Trailblazer', 141),
+    ('Brokkr-2', 142),
+    ('Chimera-1', 143),
+    ('IM-2', 144),
+    ('Artemis II', 145)
+) AS v(name, order_index);
+
+-- mtg
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('mtg', 'Magic: The Gathering Sets', 'Magic: The Gathering first 50 sets in order of release date (oldest first).')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Limited Edition Alpha', 1),
+    ('Limited Edition Beta', 2),
+    ('Arabian Nights', 3),
+    ('Antiquities', 4),
+    ('Legends', 5),
+    ('The Dark', 6),
+    ('Fallen Empires', 7),
+    ('Ice Age', 8),
+    ('Homelands', 9),
+    ('Alliances', 10),
+    ('Mirage', 11),
+    ('Visions', 12),
+    ('Weatherlight', 13),
+    ('Tempest', 14),
+    ('Stronghold', 15),
+    ('Exodus', 16),
+    ('Urza''s Saga', 17),
+    ('Urza''s Legacy', 18),
+    ('Urza''s Destiny', 19),
+    ('Mercadian Masques', 20),
+    ('Nemesis', 21),
+    ('Prophecy', 22),
+    ('Invasion', 23),
+    ('Planeshift', 24),
+    ('Apocalypse', 25),
+    ('Odyssey', 26),
+    ('Torment', 27),
+    ('Judgment', 28),
+    ('Onslaught', 29),
+    ('Legions', 30),
+    ('Scourge', 31),
+    ('Mirrodin', 32),
+    ('Darksteel', 33),
+    ('Fifth Dawn', 34),
+    ('Champions of Kamigawa', 35),
+    ('Betrayers of Kamigawa', 36),
+    ('Saviors of Kamigawa', 37),
+    ('Ravnica: City of Guilds', 38),
+    ('Guildpact', 39),
+    ('Dissension', 40),
+    ('Coldsnap', 41),
+    ('Time Spiral', 42),
+    ('Planar Chaos', 43),
+    ('Future Sight', 44),
+    ('Lorwyn', 45),
+    ('Morningtide', 46),
+    ('Shadowmoor', 47),
+    ('Eventide', 48),
+    ('Shards of Alara', 49),
+    ('Conflux', 50)
+) AS v(name, order_index);
+
+-- oregon_pop
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('oregon_pop', 'Oregon Cities by Population', 'The 20 most populated cities in oregon sorted from highest to lowest by population in 2026')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Portland', 1),
+    ('Salem', 2),
+    ('Eugene', 3),
+    ('Hillsboro', 4),
+    ('Bend', 5),
+    ('Gresham', 6),
+    ('Beaverton', 7),
+    ('Medford', 8),
+    ('Corvallis', 9),
+    ('Springfield', 10),
+    ('Tigard', 11),
+    ('Albany', 12),
+    ('Aloha', 13),
+    ('Lake Oswego', 14),
+    ('Grants Pass', 15),
+    ('Redmond', 16),
+    ('Keizer', 17),
+    ('Oregon City', 18),
+    ('McMinnville', 19),
+    ('Bethany', 20)
+) AS v(name, order_index);
+
+-- planets
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('planets', 'Planets', 'Put the planets in order by distance from the sun (closest first).')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Mercury', 1),
+    ('Venus', 2),
+    ('Earth', 3),
+    ('Mars', 4),
+    ('Jupiter', 5),
+    ('Saturn', 6),
+    ('Uranus', 7),
+    ('Neptune', 8),
+    ('Pluto', 9)
+) AS v(name, order_index);
+
+-- presidents
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('presidents', 'US Presidents', 'Put the presidents of the United States in order of their presidencies (first to most recent).')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('George Washington', 1),
+    ('John Adams', 2),
+    ('Thomas Jefferson', 3),
+    ('James Madison', 4),
+    ('James Monroe', 5),
+    ('John Quincy Adams', 6),
+    ('Andrew Jackson', 7),
+    ('Martin Van Buren', 8),
+    ('William Henry Harrison', 9),
+    ('John Tyler', 10),
+    ('James K. Polk', 11),
+    ('Zachary Taylor', 12),
+    ('Millard Fillmore', 13),
+    ('Franklin Pierce', 14),
+    ('James Buchanan', 15),
+    ('Abraham Lincoln', 16),
+    ('Andrew Johnson', 17),
+    ('Ulysses S. Grant', 18),
+    ('Rutherford B. Hayes', 19),
+    ('James A. Garfield', 20),
+    ('Chester A. Arthur', 21),
+    ('Grover Cleveland', 22),
+    ('Benjamin Harrison', 23),
+    ('Grover Cleveland', 24),
+    ('William McKinley', 25),
+    ('Theodore Roosevelt', 26),
+    ('William Howard Taft', 27),
+    ('Woodrow Wilson', 28),
+    ('Warren G. Harding', 29),
+    ('Calvin Coolidge', 30),
+    ('Herbert Hoover', 31),
+    ('Franklin D. Roosevelt', 32),
+    ('Harry S. Truman', 33),
+    ('Dwight D. Eisenhower', 34),
+    ('John F. Kennedy', 35),
+    ('Lyndon B. Johnson', 36),
+    ('Richard Nixon', 37),
+    ('Gerald Ford', 38),
+    ('Jimmy Carter', 39),
+    ('Ronald Reagan', 40),
+    ('George H. W. Bush', 41),
+    ('Bill Clinton', 42),
+    ('George W. Bush', 43),
+    ('Barack Obama', 44),
+    ('Donald Trump', 45),
+    ('Joe Biden', 46),
+    ('Donald Trump', 47)
+) AS v(name, order_index);
+
+-- retro_games
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('retro_games', 'Retro video game releases', 'Put retro video games in order from oldest to newest')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Space Invaders', 1),
+    ('Pac-Man', 2),
+    ('Tetris', 3),
+    ('Super Mario Bros.', 4),
+    ('Street Fighter II', 5),
+    ('Sonic the Hedgehog', 6),
+    ('Doom', 7),
+    ('Mega Man X', 8),
+    ('Super Metroid', 9),
+    ('Donkey Kong Country', 10),
+    ('Chrono Trigger', 11),
+    ('Pokémon Red', 12),
+    ('Final Fantasy VII', 13),
+    ('Castlevania: Symphony of the Night', 14),
+    ('GoldenEye 007', 15),
+    ('Star Fox 64', 16),
+    ('The Legend of Zelda: Ocarina of Time', 17),
+    ('Metal Gear Solid', 18),
+    ('Resident Evil 2', 19),
+    ('Metroid Prime', 20)
+) AS v(name, order_index);
+
+-- roundabout_cities
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('roundabout_cities', 'Roundabout Cities', 'Top 10 cities sorted by the most roundabouts.')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Carmel IN', 1),
+    ('Colorado Springs CO', 2),
+    ('Columia MO', 3),
+    ('Loveland CO', 4),
+    ('Austin TX', 5),
+    ('Frisco TX', 6),
+    ('Charlotte NC', 7),
+    ('Lincoln NE', 8),
+    ('Bend OR', 9),
+    ('Durham NC', 10)
+) AS v(name, order_index);
+
+-- selling_games
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('selling_games', 'Highest Selling Games', 'Put the games in order by number of copies sold')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Minecraft', 1),
+    ('Grand Theft Auto V', 2),
+    ('Wii Sports', 3),
+    ('Red Dead Redemption 2', 4),
+    ('Mario Kart 8 / Deluxe', 5),
+    ('PUBG: Battlegrounds', 6),
+    ('Terraria', 7),
+    ('The Witcher 3: Wild Hunt', 8),
+    ('Super Mario Bros', 9),
+    ('Human Fall Flat', 10)
+) AS v(name, order_index);
+
+-- stars
+WITH ins AS (
+    INSERT INTO datasets (name, title, description)
+    VALUES ('stars', 'Stars', 'Put the stars in order of distance from the Sun')
+    RETURNING id
+)
+INSERT INTO dataset_items (dataset_id, name, order_index)
+SELECT ins.id, v.name, v.order_index
+FROM ins, (VALUES
+    ('Sol', 0),
+    ('Proxima Centauri', 1),
+    ('Rigil Kentaurus & Toliman', 2),
+    ('Barnard''s Star', 3),
+    ('Wolf 359', 4),
+    ('Sirius', 5),
+    ('Luyten 726-8', 6),
+    ('Epsilon Eridani', 7),
+    ('61 Cygni A, B, & C', 8),
+    ('Procyon A & B', 9),
+    ('Epsilon Indi', 10),
+    ('Tau Ceti', 11),
+    ('GJ 1061', 12),
+    ('YZ Ceti', 13),
+    ('Luyten''s Star', 14),
+    ('Teegarden''s Star', 15),
+    ('82 G Eridani', 16)
+) AS v(name, order_index);


### PR DESCRIPTION
Add a Supabase integration to receive our category data from a production database. The `/api/data` route returns all data objects in our database. Included `schema.sql`  to set up the database instantly with a copy and paste. Included `seed.sql` fills in the dataset with all the JSON files the students created. Short setup documentation placed in `/docs` to create a remote database. Supabase has unlimited API requests with the free tier, so there isn't much of a reason to set up a local supabase, just adds extra complexity.