### PR TITLE
feat: use move cursor for group items

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,7 +60,7 @@ export default function Home() {
             key={item.name}
             value={item}
             as="div"
-            style={{ position: 'relative' }}
+            style={{ position: 'relative', 'cursor': 'move' }}
           >
             <Card variant="outlined">
               <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2, py: '12px !important' }}>


### PR DESCRIPTION
Uses the browser 'move' cursor style for movable group items.

See it live here: [lab.elkayy.net](https://lab.elkayy.net)

Closes #72 