### PR TITLE
Assignment4/issue2: Implement titles endpoint

### DIFF
--- a/src/app/api/data/titles/route.ts
+++ b/src/app/api/data/titles/route.ts
@@ -1,0 +1,38 @@
+import { getSupabaseClient } from "@/lib/supabase"
+import { DatasetTitle } from "@/types/data"
+import { NextRequest } from "next/server"
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+const MIN_LIMIT = 1
+
+/**
+ * GET `/api/data/titles`  
+ * Retrieve a list of dataset titles with pagination support. Optionally accepts the following query parameters:
+ * - `limit`: The maximum number of dataset titles to return (default: 100, max: 1000).
+ * - `cursor`: The ID of the last dataset title from the previous page (for pagination). If not provided, starts from the beginning.
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const limit = Math.min(Math.max(Number(searchParams.get('limit')) || DEFAULT_LIMIT, MIN_LIMIT), MAX_LIMIT)
+  const cursor = Number(searchParams.get('cursor')) || null
+
+  const supabase = getSupabaseClient()
+
+  let query = await supabase
+    .from('datasets')
+    .select('id, dataset_slug, title')
+    .gt('id', cursor ?? -1)
+    .order('id', { ascending: true })
+    .limit(limit)
+
+  if (query.error) {
+    return Response.json({ 
+      error: query.error.message 
+    }, { status: 500 })
+  }
+
+  const datasets = query.data as DatasetTitle[]
+  const nextCursor = datasets.length >= limit ? datasets[datasets.length - 1].id : null
+  return Response.json({ titles: datasets, nextCursor })
+}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -15,3 +15,5 @@ export interface Dataset<T = DatasetItem> {
     description: string | null
     items: T[]
 }
+
+export type DatasetTitle = Omit<Dataset, 'description' | 'items'>


### PR DESCRIPTION
This pull request implements the dataset titles endpoint as a `GET` request to `/api/data/titles`. 

It responds with a `titles` parameter that is an array of `{ id, slug, title }` objects.

This endpoint supports limiting the number of titles returned and pagination. A limit can be specified with `?limit=xxx`, and pagination is accomplished via cursoring. When a limit is provided and that number of items are returned, a `nextCursor` parameter will also be returned for pagination purposes. This implementation defines a minimum limit of `1`, a maximum limit of `1000`, and a default limit of `100`.

Closes #87 