### PR TITLE
Implement titles API endpoint

### DIFF
--- a/src/app/api/titles/route.ts
+++ b/src/app/api/titles/route.ts
@@ -1,0 +1,23 @@
+import { DatasetMeta } from "@/types/data";
+import { getSupabaseClient } from "@/lib/supabase";
+
+export async function GET() {
+  try {
+    const supabase = getSupabaseClient();
+
+    const { data, error } = await supabase
+      .from("datasets")
+      .select("id, dataset_slug, title")
+      .order("dataset_slug", { ascending: true });
+
+    if (error) throw error;
+
+    return Response.json(data as DatasetMeta[]);
+  } catch (error) {
+    console.error("Database error:", error);
+    return Response.json(
+      { error: "Failed to fetch datasets" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -15,3 +15,10 @@ export interface Dataset<T = DatasetItem> {
     description: string | null
     items: T[]
 }
+
+
+export interface DatasetMeta {
+    id: number
+    dataset_slug: string
+    title: string
+}


### PR DESCRIPTION
## Type of change
- New feature

## Description
Add `/api/titles` endpoint that retrievs dataset information without retrieving all of the items within.

## Changes
- Add `src/app/api/titles/route.ts` that retrieves all dataset's title, slug, and id in a JSON format.
- Update `src/types/data.ts` to include DatasetMeta dataype. This allows more reusability for the front-end.