### PR TITLE
Add colored feedback when submitting answer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,12 +12,11 @@ import { Dataset, DatasetItem, DatasetMeta } from '@/types/data';
 
 export default function Home() {
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [dataset, setDataset] = useState<Dataset | null>(null)
-  // const { title, description, items } = datasets[selectedIndex];
-
+  const [dataset, setDataset] = useState<Dataset | null>(null);
   const [shuffledItems, setShuffledItems] = useState<DatasetItem[]>([]);
   const [isDragging, setIsDragging] = useState(false);
-  const [datasetMeta, setDatasetMeta] = useState<DatasetMeta[]>([])
+  const [datasetMeta, setDatasetMeta] = useState<DatasetMeta[]>([]);
+  const [itemStatuses, setItemStatuses] = useState<Record<string, 'correct' | 'close' | 'wrong'>>({});
   const [feedback, setFeedback] = useState<{
     severity: 'success' | 'info',
     message: string
@@ -26,56 +25,68 @@ export default function Home() {
   useEffect(() => {
     fetch("/api/titles")
       .then((r: Response) => r.json())
-      .then((data: DatasetMeta[]) => setDatasetMeta(data))
-  }, [])
+      .then((data: DatasetMeta[]) => setDatasetMeta(data));
+  }, []);
 
   useEffect(() => {
     if (dataset) {
       const shuffled = [...dataset.items].sort(() => Math.random() - 0.5);
       setShuffledItems(shuffled);
+      setItemStatuses({});
       setFeedback(null);
     }
-
   }, [dataset]);
 
   useEffect(() => {
-    if (datasetMeta.length > selectedIndex){
-    fetch(`/api/data?name=${datasetMeta[selectedIndex].dataset_slug}`)
-      .then((r: Response) => r.json())
-      .then((data: Dataset) => setDataset(data))
+    if (datasetMeta.length > selectedIndex) {
+      fetch(`/api/data?name=${datasetMeta[selectedIndex].dataset_slug}`)
+        .then((r: Response) => r.json())
+        .then((data: Dataset) => setDataset(data));
     }
-
-  }, [selectedIndex, datasetMeta])
+  }, [selectedIndex, datasetMeta]);
 
   const handleCheckOrder = () => {
     if (dataset) {
-      const correctCount = shuffledItems.reduce((count, item, index) => {
-        return item.order === dataset.items[index].order ? count + 1 : count;
-      }, 0);
+      const statuses: Record<string, 'correct' | 'close' | 'wrong'> = {};
+      let correctCount = 0;
+
+      shuffledItems.forEach((item, index) => {
+        const correctIndex = dataset.items.findIndex(d => d.order === item.order);
+        if (correctIndex === index) {
+          statuses[item.name] = 'correct';
+          correctCount++;
+        } else if (Math.abs(correctIndex - index) <= 1) {
+          statuses[item.name] = 'close';
+        } else {
+          statuses[item.name] = 'wrong';
+        }
+      });
+
+      setItemStatuses(statuses);
 
       if (correctCount === dataset.items.length) {
-        setFeedback({
-          severity: 'success',
-          message: 'Correct! You solved the puzzle.'
-        });
+        setFeedback({ severity: 'success', message: 'Correct! You solved the puzzle.' });
       } else {
-        setFeedback({
-          severity: 'info',
-          message: `${correctCount} of ${dataset.items.length} items are in the correct position.`
-        });
+        setFeedback({ severity: 'info', message: `${correctCount} of ${dataset.items.length} items are in the correct position.` });
       }
     }
   };
 
   const handleReorder = (newOrder: DatasetItem[]) => {
     setShuffledItems(newOrder);
+    setItemStatuses({});
     setFeedback(null);
+  };
+
+  const cardBgColor = (name: string) => {
+    const status = itemStatuses[name];
+    if (status === 'correct') return 'success.light';
+    if (status === 'close') return 'warning.light';
+    return 'background.paper';
   };
 
   return (
     <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2 }}>
-
-      {/* Dropdown */}
       <FormControl fullWidth sx={{ mb: 3 }}>
         <InputLabel>Select a dataset</InputLabel>
         <Select
@@ -101,22 +112,17 @@ export default function Home() {
         )}
       </Box>
 
-      {/* Title & description from the JSON */}
-      {
-        dataset ?
-          <>
-            <Typography variant="h4" gutterBottom>{dataset.title}</Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-              {dataset.description}
-            </Typography>
-          </>
+      {dataset ? (
+        <>
+          <Typography variant="h4" gutterBottom>{dataset.title}</Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+            {dataset.description}
+          </Typography>
+        </>
+      ) : (
+        <h3>loading...</h3>
+      )}
 
-          :
-          <h3> loading... </h3>
-      }
-
-
-      {/* Item cards */}
       <Reorder.Group
         as="div"
         values={shuffledItems}
@@ -132,7 +138,14 @@ export default function Home() {
             onDragStart={() => setIsDragging(true)}
             onDragEnd={() => setIsDragging(false)}
           >
-            <Card variant="outlined" sx={{ cursor: isDragging ? 'grabbing' : 'grab' }}>
+            <Card
+              variant="outlined"
+              sx={{
+                cursor: isDragging ? 'grabbing' : 'grab',
+                bgcolor: cardBgColor(item.name),
+                transition: 'background-color 0.3s ease',
+              }}
+            >
               <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2, py: '12px !important' }}>
                 <DragHandleIcon color="action" />
                 <Typography variant="body1">{item.name}</Typography>
@@ -143,4 +156,4 @@ export default function Home() {
       </Reorder.Group>
     </Box>
   );
-};
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,9 +47,22 @@ export default function Home() {
 
   const handleCheckOrder = () => {
     if (dataset) {
-      const correctCount = shuffledItems.reduce((count, item, index) => {
-        return item.order === dataset.items[index].order ? count + 1 : count;
-      }, 0);
+      const statuses: Record<string, 'correct' | 'close' | 'wrong'> = {};
+      let correctCount = 0;
+
+      shuffledItems.forEach((item, index) => {
+        const correctIndex = dataset.items.findIndex(d => d.order === item.order);
+        if (correctIndex === index) {
+          statuses[item.name] = 'correct';
+          correctCount++;
+        } else if (Math.abs(correctIndex - index) <= 1) {
+          statuses[item.name] = 'close';
+        } else {
+          statuses[item.name] = 'wrong';
+        }
+      });
+
+      setItemStatuses(statuses);
 
       if (correctCount === dataset.items.length) {
         setFeedback({ severity: 'success', message: 'Correct! You solved the puzzle.' });
@@ -118,7 +131,7 @@ export default function Home() {
       >
         {shuffledItems.map((item) => (
           <Reorder.Item
-            key={item.order}
+            key={item.name}
             value={item}
             as="div"
             style={{ position: 'relative' }}


### PR DESCRIPTION
## Summary


Add visual feedback to list sorting game cards: green highlight for correctly placed items, yellow for items within one position of correct, clearing on any reorder.

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs / chore

---

## Changes

- Added `itemStatuses` state to track per-item feedback after submission
- Updated `handleCheckOrder` to compute each item's status using `findIndex` on `item.order` for position-independent comparison
- Added `cardBgColor` helper that maps status --> MUI `bgcolor` token (`success.light`, `warning.light`, or `background.paper`)
- Statuses are cleared on reorder (`handleReorder`) and on dataset change (`useEffect` on `dataset`) to prevent stale highlights
- Added `transition: background-color 0.3s ease` on cards for a smooth reveal animation

---

## Testing

- [ ] Drag items to correct order --> all cards turn green, success alert shown
- [ ] Drag one item off by one position --> that card turns yellow
- [ ] Cards more than one position off --> no highlight (default background)
- [ ] Reordering after a check clears all highlights
- [ ] Switching datasets clears all highlights

---

## Notes

- Correct position is resolved via `dataset.items.findIndex(d => d.order === item.order)` rather than array index comparison, so the logic is robust regardless of how the source dataset is ordered.
- No new dependencies introduced.