### PR TITLE
Added Edit & Delete Functionality

### DIFF
--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -60,6 +60,7 @@ async function seedSupabase() {
               dataset_slug,
               title: data.title,
               description: data.description || '',
+              is_builtin: true,
               updated_at: new Date().toISOString(),
             },
             { onConflict: 'dataset_slug' }

--- a/src/app/api/data/DELETE.ts
+++ b/src/app/api/data/DELETE.ts
@@ -1,6 +1,6 @@
 import * as z from "zod";
 import { getSupabaseClient } from "@/lib/supabase";
-import { NextRequest } from "next/server";
+import { isBuiltinDataset } from "@/lib/builtinDatasets";
 
 export async function DELETE(
   request: Request) {
@@ -9,6 +9,12 @@ export async function DELETE(
   const supabase = getSupabaseClient()
 
   if (slug) {
+    // Check if dataset is built-in
+    const isBuiltin = await isBuiltinDataset(slug);
+    if (isBuiltin) {
+      return Response.json({ error: "Built-in datasets cannot be deleted" }, { status: 403 });
+    }
+
     const { data, error } = await supabase
       .from('datasets')
       .delete()

--- a/src/app/api/data/GET.ts
+++ b/src/app/api/data/GET.ts
@@ -1,5 +1,6 @@
 import { Dataset, DatasetDatabaseItem } from '@/types/data'
 import { getSupabaseClient } from '@/lib/supabase'
+import { isBuiltinDataset } from '@/lib/builtinDatasets'
 
 export async function GET(request: Request) {
     const { searchParams } = new URL(request.url)
@@ -34,10 +35,14 @@ export async function GET(request: Request) {
                 throw itemsError
             }
 
+            const isBuiltin = await isBuiltinDataset(name)
+
             const dataFile: Dataset = {
                 id: dataset.id,
+                dataset_slug: dataset.dataset_slug,
                 title: dataset.title,
                 description: dataset.description || '',
+                is_builtin: isBuiltin,
                 items: (items || []).map(item => ({
                     name: item.item_name,
                     order: item.item_order
@@ -60,9 +65,13 @@ export async function GET(request: Request) {
         }
 
         const allData: Record<string, Dataset> = {}
+        const builtinSlugs = await Promise.all(
+            datasets.map(ds => isBuiltinDataset(ds.dataset_slug || ''))
+        )
 
         // fetch items for each dataset
-        for (const dataset of datasets || []) {
+        for (let i = 0; i < (datasets || []).length; i++) {
+            const dataset = datasets[i]
             const { data: itemsData, error: itemsError } = await supabase
                 .from('dataset_items')
                 .select('item_name, item_order')
@@ -77,8 +86,10 @@ export async function GET(request: Request) {
 
             allData[dataset.dataset_slug ?? ""] = {
                 id: dataset.id,
+                dataset_slug: dataset.dataset_slug,
                 title: dataset.title,
                 description: dataset.description || '',
+                is_builtin: builtinSlugs[i],
                 items: (items || []).map(item => ({
                     name: item.item_name,
                     order: item.item_order

--- a/src/app/api/data/PATCH.ts
+++ b/src/app/api/data/PATCH.ts
@@ -1,5 +1,6 @@
 import * as z from "zod";
 import { getSupabaseClient } from "@/lib/supabase";
+import { isBuiltinDataset } from "@/lib/builtinDatasets";
 import { NextRequest } from "next/server";
 
 const Data = z.object({
@@ -19,6 +20,12 @@ export async function PATCH(
     const slug = searchParams.get('slug')
     if (slug == null){
       return Response.json({ error: "Missing required query parameter: slug" }, { status: 400 })
+    }
+
+    // Check if dataset is built-in
+    const isBuiltin = await isBuiltinDataset(slug);
+    if (isBuiltin) {
+      return Response.json({ error: "Built-in datasets cannot be edited" }, { status: 403 });
     }
 
     const supabase = getSupabaseClient();

--- a/src/app/api/titles/route.ts
+++ b/src/app/api/titles/route.ts
@@ -1,5 +1,6 @@
 import { DatasetMeta } from "@/types/data";
 import { getSupabaseClient } from "@/lib/supabase";
+import { isBuiltinDataset } from "@/lib/builtinDatasets";
 
 export async function GET() {
   try {
@@ -12,7 +13,15 @@ export async function GET() {
 
     if (error) throw error;
 
-    return Response.json(data as DatasetMeta[]);
+    // Check which datasets are built-in
+    const datasetsWithBuiltin = await Promise.all(
+      (data || []).map(async (ds) => ({
+        ...ds,
+        is_builtin: await isBuiltinDataset(ds.dataset_slug)
+      }))
+    );
+
+    return Response.json(datasetsWithBuiltin as DatasetMeta[]);
   } catch (error) {
     console.error("Database error:", error);
     return Response.json(

--- a/src/app/edit/[slug]/page.tsx
+++ b/src/app/edit/[slug]/page.tsx
@@ -1,0 +1,317 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import {
+  Box, Typography, TextField, Button, IconButton, Alert, Dialog, DialogTitle, DialogContent, DialogActions
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Dataset } from '@/types/data';
+
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+$/, '');
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    if ('errors' in error) return extractErrorMessage((error as Record<string, unknown>).errors);
+    const entries = Object.entries(error as Record<string, unknown>);
+    if (entries.length > 0) return entries.map(([k, v]) => `${k}: ${extractErrorMessage(v)}`).join(', ');
+  }
+  if (Array.isArray(error)) return error.map(extractErrorMessage).join(', ');
+  return 'An unknown error occurred';
+}
+
+export default function EditDatasetPage() {
+  const router = useRouter();
+  const params = useParams();
+  const slug = params.slug as string;
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [items, setItems] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [isBuiltin, setIsBuiltin] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  // Load dataset on mount
+  useEffect(() => {
+    const loadDataset = async () => {
+      try {
+        const res = await fetch(`/api/data?name=${slug}`);
+        if (!res.ok) {
+          setError('Dataset not found');
+          return;
+        }
+
+        const dataset: Dataset = await res.json();
+
+        if (dataset.is_builtin) {
+          setError('Built-in datasets cannot be edited');
+          setIsBuiltin(true);
+          return;
+        }
+
+        setTitle(dataset.title);
+        setDescription(dataset.description || '');
+        setItems(dataset.items.map(item => item.name));
+        setIsBuiltin(dataset.is_builtin || false);
+      } catch (err) {
+        setError('Failed to load dataset');
+      } finally {
+        setInitialLoading(false);
+      }
+    };
+
+    loadDataset();
+  }, [slug]);
+
+  const handleAddItem = () => setItems(prev => [...prev, '']);
+
+  const handleItemChange = (index: number, value: string) => {
+    setItems(prev => prev.map((item, i) => (i === index ? value : item)));
+  };
+
+  const handleRemoveItem = (index: number) => {
+    setItems(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSave = async () => {
+    setError(null);
+
+    const filledItems = items.filter(name => name.trim());
+
+    if (!title.trim()) { setError('Dataset name is required'); return; }
+    if (filledItems.length < 2) { setError('At least 2 items are required'); return; }
+
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/data?slug=${slug}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || undefined,
+          items: filledItems.map((name, index) => ({ name: name.trim(), order: index + 1 })),
+        }),
+      });
+
+      if (res.ok) {
+        router.push('/');
+      } else {
+        const data = await res.json();
+        setError(extractErrorMessage(data.error));
+      }
+    } catch {
+      setError('Network error — please try again');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/data?slug=${slug}`, {
+        method: 'DELETE',
+      });
+
+      if (res.ok) {
+        router.push('/');
+      } else {
+        const data = await res.json();
+        setError(extractErrorMessage(data.error));
+      }
+    } catch {
+      setError('Network error — please try again');
+    } finally {
+      setDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  if (initialLoading) {
+    return (
+      <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2 }}>
+        <Typography>Loading...</Typography>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+          <IconButton
+            onClick={() => router.push('/')}
+            aria-label="close"
+          >
+            <CloseIcon sx={{ fontSize: 36, fontWeight: 'bold' }} />
+          </IconButton>
+        </Box>
+        <Alert severity="error">{error}</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2, position: 'relative', pb: 4 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+        <IconButton
+          onClick={() => router.push('/')}
+          aria-label="close"
+        >
+          <CloseIcon sx={{ fontSize: 36, fontWeight: 'bold' }} />
+        </IconButton>
+      </Box>
+
+      <Typography variant="h5" sx={{ mb: 3, fontWeight: 'bold' }}>Edit Dataset</Typography>
+
+      <Box sx={{ mb: 3 }}>
+        <TextField
+          fullWidth
+          label="Data set name"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          disabled={loading}
+          slotProps={{ input: { 'aria-label': 'dataset name' } }}
+        />
+      </Box>
+
+      <TextField
+        fullWidth
+        label="Description"
+        multiline
+        rows={6}
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        disabled={loading}
+        sx={{ mb: 3 }}
+      />
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 3 }}>
+        {items.map((item, index) => (
+          <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <Typography sx={{ width: 24, textAlign: 'right', flexShrink: 0, color: 'text.secondary' }}>
+              {index + 1}
+            </Typography>
+            <TextField
+              fullWidth
+              value={item}
+              onChange={(e) => handleItemChange(index, e.target.value)}
+              disabled={loading}
+              placeholder={index === 0 ? '1st Item' : index === 1 ? '2nd Item' : `${index + 1}th Item`}
+              size="small"
+            />
+            {items.length > 2 && (
+              <IconButton
+                onClick={() => handleRemoveItem(index)}
+                disabled={loading}
+                size="small"
+                aria-label="remove item"
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 4 }}>
+        <IconButton
+          onClick={handleAddItem}
+          disabled={loading}
+          aria-label="add item"
+        >
+          <AddIcon sx={{ fontSize: 52 }} />
+        </IconButton>
+        <Typography variant="body2" align="center">Add new item</Typography>
+      </Box>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={() => router.push('/')}
+          disabled={loading}
+          sx={{
+            flex: 1,
+            py: 1.5,
+            borderColor: '#e89b00',
+            color: '#e89b00',
+            borderWidth: 2,
+            fontWeight: 'bold',
+            '&:hover': { borderColor: '#c47e00', color: '#c47e00', borderWidth: 2, bgcolor: 'transparent' },
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={handleSave}
+          disabled={loading}
+          sx={{
+            flex: 1,
+            py: 1.5,
+            borderColor: '#3700cc',
+            color: '#3700cc',
+            borderWidth: 2,
+            fontWeight: 'bold',
+            '&:hover': { borderColor: '#2500aa', color: '#2500aa', borderWidth: 2, bgcolor: 'transparent' },
+          }}
+        >
+          {loading ? 'Saving...' : 'SAVE'}
+        </Button>
+      </Box>
+
+      <Button
+        variant="outlined"
+        onClick={() => setShowDeleteConfirm(true)}
+        disabled={loading || deleting}
+        fullWidth
+        sx={{
+          py: 1.5,
+          borderColor: '#d32f2f',
+          color: '#d32f2f',
+          borderWidth: 2,
+          fontWeight: 'bold',
+          '&:hover': { borderColor: '#b71c1c', color: '#b71c1c', borderWidth: 2, bgcolor: 'transparent' },
+        }}
+      >
+        Delete Dataset
+      </Button>
+
+      <Dialog open={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)}>
+        <DialogTitle>Confirm Delete</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete this dataset? This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowDeleteConfirm(false)}>Cancel</Button>
+          <Button
+            onClick={handleDelete}
+            disabled={deleting}
+            color="error"
+            variant="contained"
+          >
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/components/PuzzleGame.tsx
+++ b/src/components/PuzzleGame.tsx
@@ -71,7 +71,7 @@ export default function PuzzleGame({ dataset }: PuzzleGameProps) {
 
   return (
     <>
-      <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+      <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
         <Button variant="contained" onClick={handleCheckOrder}>
           Check Order
         </Button>
@@ -80,6 +80,15 @@ export default function PuzzleGame({ dataset }: PuzzleGameProps) {
         </Button>
         <Button variant="contained" component={Link} href="/add">
           Add New Dataset
+        </Button>
+        <Button
+          variant="contained"
+          component={Link}
+          href={dataset && !dataset.is_builtin ? `/edit/${dataset.dataset_slug}` : '#'}
+          disabled={!dataset || dataset.is_builtin}
+          title={dataset?.is_builtin ? 'Built-in datasets cannot be edited' : 'Edit this dataset'}
+        >
+          Edit Dataset
         </Button>
       </Box>
 

--- a/src/lib/builtinDatasets.ts
+++ b/src/lib/builtinDatasets.ts
@@ -1,0 +1,28 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+let builtinDatasetSlugs: string[] | null = null;
+
+export async function getBuiltinDatasetSlugs(): Promise<string[]> {
+  if (builtinDatasetSlugs !== null) {
+    return builtinDatasetSlugs;
+  }
+
+  try {
+    const dataDir = path.join(process.cwd(), 'data');
+    const files = await fs.readdir(dataDir);
+    builtinDatasetSlugs = files
+      .filter(f => f.endsWith('.json'))
+      .map(f => f.replace('.json', ''))
+      .sort();
+    return builtinDatasetSlugs;
+  } catch (error) {
+    console.error('Failed to read built-in datasets:', error);
+    return [];
+  }
+}
+
+export async function isBuiltinDataset(slug: string): Promise<boolean> {
+  const slugs = await getBuiltinDatasetSlugs();
+  return slugs.includes(slug);
+}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -13,6 +13,7 @@ export interface Dataset<T = DatasetItem> {
     dataset_slug?: string
     title: string
     description: string | null
+    is_builtin?: boolean
     items: T[]
 }
 
@@ -21,4 +22,5 @@ export interface DatasetMeta {
     id: number
     dataset_slug: string
     title: string
+    is_builtin: boolean
 }

--- a/supabase/migrations/20260419000000_add_is_builtin_to_datasets.sql
+++ b/supabase/migrations/20260419000000_add_is_builtin_to_datasets.sql
@@ -1,0 +1,4 @@
+-- Add is_builtin column to datasets table
+-- This tracks whether a dataset was loaded from the seed script (built-in) or created by a user (custom)
+
+ALTER TABLE datasets ADD COLUMN IF NOT EXISTS is_builtin BOOLEAN DEFAULT false;


### PR DESCRIPTION
### Changes
I have added a button to the main page that allows you to edit the currently open dataset. From this new edit menu you can add or remove items, change the title, or the description, much like when creating a new dataset. You can also delete this dataset, which gives a warning.

This function does not work with any built-in datasets that have files within the source code.

### Purpose
This function now lets you test the ADD function without cluttering your personal localhost. You can also freely add, edit, or remove your own personal datasets. Built-in datasets cannot be changed however. Perhaps in the future we can make a way to differentiate built-in datasets from custom ones?

### Notes
Edit button is grayed out for built-in datasets. To test you can create a new dataset and then edit or delete it. 

Adding `/edit/[dataset name]` to the URL takes you to the dataset's edit page. This will not work with built-in datasets, and will show an error warning the user. 