### PR TITLE
Add Typescript check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "tsc --noEmit && echo 'TypeScript check passed!'",
     "db:start": "supabase start",
     "db:stop": "supabase stop",
     "db:status": "supabase status",


### PR DESCRIPTION
## Type of Change
New developer feature.

## Description
Added a new script that runs the typescript checker. It can be ran with `npm run test`.  This command does the majority of the testing that is done when building. No testing suite was added because Dan mainly wanted a way to run the pretest scripts ran before building. When you add linting to the test suite as well (already included with `npm run lint`) everything that build tests catch would be caught with these two commands.

## Changes
Add `test` command in `package.json`.

## Tests
- When no typescript issues are present it prints out `TypeScript check passed!`.
- When there are typescript issues they are displayed in the terminal.