### PR TITLE
assignment9/issue1: added tests for puzzle logic and order verification

### DIFF
--- a/tests/unit/puzzle.spec.ts
+++ b/tests/unit/puzzle.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { getItemStatus, shuffleItems, countCorrectItems } from '@/utils/puzzle'
+import { DatasetItem } from '@/types/data'
+
+describe('getItemStatus', () => {
+  const mockItem: DatasetItem = { name: 'Item', order: 1 }
+
+  it('should return default status when no feedback', () => {
+    const status = getItemStatus(mockItem, 0, false)
+    expect(status).toBe('default')
+  })
+
+  it('should return correct when item is in right position', () => {
+    const status = getItemStatus(mockItem, 0, true)
+    expect(status).toBe('correct')
+  })
+
+  it('should return close when item is off by 1 position', () => {
+    const item: DatasetItem = { name: 'Item', order: 2 }
+    const status = getItemStatus(item, 0, true)
+    expect(status).toBe('close')
+  })
+
+  it('should return close when item is off by 2 positions', () => {
+    const item: DatasetItem = { name: 'Item', order: 3 }
+    const status = getItemStatus(item, 0, true)
+    expect(status).toBe('close')
+  })
+
+  it('should return wrong when item is off by more than 2 positions', () => {
+    const item: DatasetItem = { name: 'Item', order: 5 }
+    const status = getItemStatus(item, 0, true)
+    expect(status).toBe('wrong')
+  })
+
+  it('should handle items at different indices', () => {
+    const item: DatasetItem = { name: 'Item', order: 5 }
+    // At index 1, order 5 would be off by |5 - 2| = 3
+    const status = getItemStatus(item, 1, true)
+    expect(status).toBe('wrong')
+  })
+})
+
+describe('shuffleItems', () => {
+  it('should return an array of same length', () => {
+    const items: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const shuffled = shuffleItems(items)
+    expect(shuffled).toHaveLength(3)
+  })
+
+  it('should contain all original items', () => {
+    const items: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const shuffled = shuffleItems(items)
+    const names = shuffled.map(i => i.name).sort()
+    expect(names).toEqual(['A', 'B', 'C'])
+  })
+
+  it('should not modify original array', () => {
+    const items: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+    ]
+    const original = [...items]
+    shuffleItems(items)
+    expect(items).toEqual(original)
+  })
+
+  it('should handle empty array', () => {
+    const items: DatasetItem[] = []
+    const shuffled = shuffleItems(items)
+    expect(shuffled).toHaveLength(0)
+  })
+
+  it('should handle single item', () => {
+    const items: DatasetItem[] = [{ name: 'A', order: 1 }]
+    const shuffled = shuffleItems(items)
+    expect(shuffled).toHaveLength(1)
+    expect(shuffled[0]).toEqual(items[0])
+  })
+})
+
+describe('countCorrectItems', () => {
+  it('should count all correct items', () => {
+    const shuffled: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const correct: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const count = countCorrectItems(shuffled, correct)
+    expect(count).toBe(3)
+  })
+
+  it('should count no correct items', () => {
+    const shuffled: DatasetItem[] = [
+      { name: 'C', order: 3 },
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+    ]
+    const correct: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const count = countCorrectItems(shuffled, correct)
+    expect(count).toBe(0)
+  })
+
+  it('should count partial correct items', () => {
+    const shuffled: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'C', order: 3 },
+      { name: 'B', order: 2 },
+    ]
+    const correct: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const count = countCorrectItems(shuffled, correct)
+    expect(count).toBe(1)
+  })
+
+  it('should handle empty arrays', () => {
+    const count = countCorrectItems([], [])
+    expect(count).toBe(0)
+  })
+})

--- a/tests/unit/verifyOrder.spec.ts
+++ b/tests/unit/verifyOrder.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { getItemDirections } from '@/lib/verifyOrder'
+import { DatasetItem } from '@/types/data'
+
+describe('getItemDirections', () => {
+  it('should return empty map for already sorted array', () => {
+    const items: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const directions = getItemDirections(items)
+    expect(directions.size).toBe(0)
+  })
+
+  it('should identify items that need to move up', () => {
+    const items: DatasetItem[] = [
+      { name: 'B', order: 2 },
+      { name: 'A', order: 1 },
+      { name: 'C', order: 3 },
+    ]
+    const directions = getItemDirections(items)
+    expect(directions.get(0)).toBe('down')
+    expect(directions.get(1)).toBe('up')
+  })
+
+  it('should identify items that need to move down', () => {
+    const items: DatasetItem[] = [
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+      { name: 'A', order: 1 },
+    ]
+    const directions = getItemDirections(items)
+    expect(directions.get(0)).toBe('down')
+    expect(directions.get(1)).toBe('down')
+    expect(directions.get(2)).toBe('up')
+  })
+
+  it('should handle completely reversed array', () => {
+    const items: DatasetItem[] = [
+      { name: 'C', order: 3 },
+      { name: 'B', order: 2 },
+      { name: 'A', order: 1 },
+    ]
+    const directions = getItemDirections(items)
+    expect(directions.get(0)).toBe('down')
+    expect(directions.get(1)).toBe(undefined) // B is already in correct position
+    expect(directions.get(2)).toBe('up')
+  })
+
+  it('should not include items in correct position in map', () => {
+    const items: DatasetItem[] = [
+      { name: 'A', order: 1 },
+      { name: 'B', order: 2 },
+      { name: 'C', order: 3 },
+    ]
+    const directions = getItemDirections(items)
+    expect(directions.has(0)).toBe(false)
+    expect(directions.has(1)).toBe(false)
+    expect(directions.has(2)).toBe(false)
+  })
+
+  it('should handle single item', () => {
+    const items: DatasetItem[] = [{ name: 'A', order: 1 }]
+    const directions = getItemDirections(items)
+    expect(directions.size).toBe(0)
+  })
+
+  it('should handle two items', () => {
+    const items: DatasetItem[] = [
+      { name: 'B', order: 2 },
+      { name: 'A', order: 1 },
+    ]
+    const directions = getItemDirections(items)
+    expect(directions.get(0)).toBe('down')
+    expect(directions.get(1)).toBe('up')
+  })
+})


### PR DESCRIPTION
## Overview

This change adds a new directory for unit tests as well as two test files; one for puzzle logic and one for order verification.

## Type of Change

Testing

## Purpose

We set up our test suite last week, and we needed to get some basic logic tests written to ensure that the puzzle logic and order verification still work as intended after making future changes.

## Implementation

* Created the file `puzzle.spec.ts` that contains puzzle logic tests
     * `getItemStatus()` has tests to verify feedback logic.
     * `shuffleItems()`  has tests to verify shuffle logic.
     *  `countCorrectItems` has tests to verify if the correct items are counted correctly.
* Created the file `verifyOrder.spec.ts` which has tests for sorting and directional logic
    * `getItemDirections()` contains all tests in this file.
 
## Impacts of this Change

* Unit tests are now executed and currently pass when executing "npm run check"
* Logic is now under test for most of the puzzle features.

## Notes

* I kept playwright tests in the test folder and they currently fail. I did not want to modify them at all. All unit tests currently pass.