### PR TITLE
I was personally assigned an issue!

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,11 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  Box, Typography, TextField, Button, IconButton, Alert
-} from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
-import AddIcon from '@mui/icons-material/Add';
+import DatasetForm, { DatasetFormValues } from "@/components/DatasetForm";
 
 function slugify(title: string): string {
   return title
@@ -16,42 +12,34 @@ function slugify(title: string): string {
     .replace(/-+$/, '');
 }
 
-function extractErrorMessage(error: unknown): string {
-  if (typeof error === 'string') return error;
-  if (error && typeof error === 'object') {
-    if ('errors' in error) return extractErrorMessage((error as Record<string, unknown>).errors);
-    const entries = Object.entries(error as Record<string, unknown>);
-    if (entries.length > 0) return entries.map(([k, v]) => `${k}: ${extractErrorMessage(v)}`).join(', ');
-  }
-  if (Array.isArray(error)) return error.map(extractErrorMessage).join(', ');
-  return 'An unknown error occurred';
-}
-
 export default function AddDatasetPage() {
   const router = useRouter();
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
-  const [items, setItems] = useState(['', '']);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleAddItem = () => setItems(prev => [...prev, '']);
-
-  const handleItemChange = (index: number, value: string) => {
-    setItems(prev => prev.map((item, i) => (i === index ? value : item)));
-  };
-
-  const handleSave = async () => {
+  const handleSave = async ({ title, description, items }: DatasetFormValues) => {
     setError(null);
 
     const slug = slugify(title);
     const filledItems = items.filter(name => name.trim());
 
-    if (!title.trim()) { setError('Dataset name is required'); return; }
-    if (slug.length < 3) { setError('Dataset name must be at least 3 characters'); return; }
-    if (filledItems.length < 2) { setError('At least 2 items are required'); return; }
+    if (!title.trim()) {
+      setError('Dataset name is required');
+      return;
+    }
+
+    if (slug.length < 3) {
+      setError('Dataset name must be at least 3 characters');
+      return;
+    }
+
+    if (filledItems.length < 2) {
+      setError('At least 2 items are required');
+      return;
+    }
 
     setLoading(true);
+
     try {
       const res = await fetch('/api/data', {
         method: 'POST',
@@ -60,7 +48,10 @@ export default function AddDatasetPage() {
           slug,
           title: title.trim(),
           description: description.trim() || undefined,
-          items: filledItems.map((name, index) => ({ name: name.trim(), order: index + 1 })),
+          items: filledItems.map((name, index) => ({
+            name: name.trim(),
+            order: index + 1,
+          })),
         }),
       });
 
@@ -68,7 +59,7 @@ export default function AddDatasetPage() {
         router.push('/');
       } else {
         const data = await res.json();
-        setError(extractErrorMessage(data.error));
+        setError(data.error || 'Failed to save dataset');
       }
     } catch {
       setError('Network error — please try again');
@@ -78,96 +69,11 @@ export default function AddDatasetPage() {
   };
 
   return (
-    <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2, position: 'relative', pb: 4 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
-        <IconButton
-          onClick={() => router.back()}
-          aria-label="close"
-        >
-          <CloseIcon sx={{ fontSize: 36, fontWeight: 'bold' }} />
-        </IconButton>
-      </Box>
-
-      <Box sx={{ mb: 3 }}>
-        <TextField
-          fullWidth
-          label="Data set name"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          slotProps={{ input: { 'aria-label': 'dataset name' } }}
-        />
-      </Box>
-
-      <TextField
-        fullWidth
-        label="Description"
-        multiline
-        rows={6}
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        sx={{ mb: 3 }}
-      />
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 3 }}>
-        {items.map((item, index) => (
-          <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            <Typography sx={{ width: 24, textAlign: 'right', flexShrink: 0, color: 'text.secondary' }}>
-              {index + 1}
-            </Typography>
-            <TextField
-              fullWidth
-              value={item}
-              onChange={(e) => handleItemChange(index, e.target.value)}
-              placeholder={index === 0 ? '1st Item' : index === 1 ? '2nd Item' : index === 0 ? '3rd Item' : `${index + 1}th Item`}
-              size="small"
-            />
-          </Box>
-        ))}
-      </Box>
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 4 }}>
-        <IconButton onClick={handleAddItem} aria-label="add item">
-          <AddIcon sx={{ fontSize: 52 }} />
-        </IconButton>
-        <Typography variant="body2" align="center">Add new item</Typography>
-      </Box>
-
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-
-      <Box sx={{ display: 'flex', gap: 2 }}>
-        <Button
-          variant="outlined"
-          onClick={() => router.push('/')}
-          disabled={loading}
-          sx={{
-            flex: 1,
-            py: 1.5,
-            borderColor: '#e89b00',
-            color: '#e89b00',
-            borderWidth: 2,
-            fontWeight: 'bold',
-            '&:hover': { borderColor: '#c47e00', color: '#c47e00', borderWidth: 2, bgcolor: 'transparent' },
-          }}
-        >
-          Cancel
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={handleSave}
-          disabled={loading}
-          sx={{
-            flex: 1,
-            py: 1.5,
-            borderColor: '#3700cc',
-            color: '#3700cc',
-            borderWidth: 2,
-            fontWeight: 'bold',
-            '&:hover': { borderColor: '#2500aa', color: '#2500aa', borderWidth: 2, bgcolor: 'transparent' },
-          }}
-        >
-          {loading ? 'Saving...' : 'SAVE'}
-        </Button>
-      </Box>
-    </Box>
+    <DatasetForm
+      loading={loading}
+      error={error}
+      onSave={handleSave}
+      onCancel={() => router.push('/')}
+    />
   );
 }

--- a/src/app/update/[slug]/page.tsx
+++ b/src/app/update/[slug]/page.tsx
@@ -2,14 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import {
-  Box, Typography, TextField, Button, IconButton, Alert
-} from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
-import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
-
+import { Box, Typography, Alert } from '@mui/material';
 import { Dataset } from '@/types/data';
+import DatasetForm, { DatasetFormValues } from '@/components/DatasetForm';
 
 function slugify(title: string): string {
   return title
@@ -44,12 +39,9 @@ function extractErrorMessage(error: unknown): string {
 export default function UpdateDatasetPage() {
   const router = useRouter();
   const params = useParams<{ slug: string }>();
-
   const slug = params.slug;
 
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
-  const [items, setItems] = useState<string[]>(['', '']);
+  const [dataset, setDataset] = useState<Dataset | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadingDataset, setLoadingDataset] = useState(true);
@@ -66,9 +58,7 @@ export default function UpdateDatasetPage() {
         return r.json();
       })
       .then((data: Dataset) => {
-        setTitle(data.title);
-        setDescription(data.description || '');
-        setItems(data.items.map(item => item.name));
+        setDataset(data);
         setError(null);
       })
       .catch(() => {
@@ -79,17 +69,7 @@ export default function UpdateDatasetPage() {
       });
   }, [slug]);
 
-  const handleAddItem = () => setItems(prev => [...prev, '']);
-
-  const handleItemChange = (index: number, value: string) => {
-    setItems(prev => prev.map((item, i) => (i === index ? value : item)));
-  };
-
-  const handleDeleteItem = (index: number) => {
-    setItems(prev => prev.filter((_, i) => i !== index));
-  };
-
-  const handleSave = async () => {
+  const handleSave = async ({ title, description, items }: DatasetFormValues) => {
     setError(null);
 
     const newSlug = slugify(title);
@@ -117,7 +97,7 @@ export default function UpdateDatasetPage() {
       });
 
       if (res.ok) {
-        router.push(`/puzzle/${newSlug}`);
+        router.push('/');
       } else {
         const data = await res.json();
         setError(extractErrorMessage(data.error));
@@ -165,117 +145,26 @@ export default function UpdateDatasetPage() {
     );
   }
 
+  if (!dataset) {
+    return (
+      <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2 }}>
+        <Alert severity="error">{error || 'Dataset not found'}</Alert>
+      </Box>
+    );
+  }
+
   return (
-    <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2, position: 'relative', pb: 4 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
-        <IconButton
-          onClick={() => router.back()}
-          aria-label="close"
-        >
-          <CloseIcon sx={{ fontSize: 36, fontWeight: 'bold' }} />
-        </IconButton>
-      </Box>
-
-      <Box sx={{ mb: 3 }}>
-        <TextField
-          fullWidth
-          label="Dataset name"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          slotProps={{ input: { 'aria-label': 'dataset name' } }}
-        />
-      </Box>
-
-      <TextField
-        fullWidth
-        label="Description"
-        multiline
-        rows={6}
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        sx={{ mb: 3 }}
-      />
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 3 }}>
-        {items.map((item, index) => (
-          <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            <Typography sx={{ width: 24, textAlign: 'right', flexShrink: 0, color: 'text.secondary' }}>
-              {index + 1}
-            </Typography>
-
-            <TextField
-              fullWidth
-              value={item}
-              onChange={(e) => handleItemChange(index, e.target.value)}
-              placeholder={index === 0 ? '1st Item' : index === 1 ? '2nd Item' : index === 2 ? '3rd Item' : `${index + 1}th Item`}
-              size="small"
-            />
-
-            <IconButton
-              onClick={() => handleDeleteItem(index)}
-              aria-label="delete item"
-              disabled={items.length <= 2}
-            >
-              <DeleteIcon />
-            </IconButton>
-          </Box>
-        ))}
-      </Box>
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 4 }}>
-        <IconButton onClick={handleAddItem} aria-label="add item">
-          <AddIcon sx={{ fontSize: 52 }} />
-        </IconButton>
-        <Typography variant="body2" align="center">Add new item</Typography>
-      </Box>
-
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-
-      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-        <Button
-          variant="outlined"
-          onClick={() => router.push('/')}
-          disabled={loading}
-          sx={{
-            flex: 1,
-            py: 1.5,
-            borderColor: '#e89b00',
-            color: '#e89b00',
-            borderWidth: 2,
-            fontWeight: 'bold',
-            '&:hover': { borderColor: '#c47e00', color: '#c47e00', borderWidth: 2, bgcolor: 'transparent' },
-          }}
-        >
-          Cancel
-        </Button>
-
-        <Button
-          variant="outlined"
-          onClick={handleSave}
-          disabled={loading}
-          sx={{
-            flex: 1,
-            py: 1.5,
-            borderColor: '#3700cc',
-            color: '#3700cc',
-            borderWidth: 2,
-            fontWeight: 'bold',
-            '&:hover': { borderColor: '#2500aa', color: '#2500aa', borderWidth: 2, bgcolor: 'transparent' },
-          }}
-        >
-          {loading ? 'Saving...' : 'SAVE'}
-        </Button>
-      </Box>
-
-      <Button
-        variant="outlined"
-        color="error"
-        fullWidth
-        onClick={handleDeleteDataset}
-        disabled={loading}
-      >
-        Delete Dataset
-      </Button>
-    </Box>
+    <DatasetForm
+      initialTitle={dataset.title}
+      initialDescription={dataset.description || ''}
+      initialItems={dataset.items.map(item => item.name)}
+      loading={loading}
+      error={error}
+      saveLabel="SAVE"
+      showDelete
+      onSave={handleSave}
+      onCancel={() => router.push('/')}
+      onDelete={handleDeleteDataset}
+    />
   );
 }

--- a/src/components/DatasetForm.tsx
+++ b/src/components/DatasetForm.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Box, Typography, TextField, Button, IconButton, Alert
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+
+export type DatasetFormValues = {
+  title: string;
+  description: string;
+  items: string[];
+};
+
+type DatasetFormProps = {
+  initialTitle?: string;
+  initialDescription?: string;
+  initialItems?: string[];
+  loading?: boolean;
+  error?: string | null;
+  saveLabel?: string;
+  showDelete?: boolean;
+  onSave: (values: DatasetFormValues) => void;
+  onCancel: () => void;
+  onDelete?: () => void;
+};
+
+const defaultItems = ['', ''];
+
+export default function DatasetForm({
+  initialTitle = '',
+  initialDescription = '',
+  initialItems = defaultItems,
+  loading = false,
+  error = null,
+  saveLabel = 'SAVE',
+  showDelete = false,
+  onSave,
+  onCancel,
+  onDelete,
+}: DatasetFormProps) {
+  const [title, setTitle] = useState(initialTitle);
+  const [description, setDescription] = useState(initialDescription);
+  const [items, setItems] = useState<string[]>(initialItems);
+
+  useEffect(() => {
+    setTitle(initialTitle);
+    setDescription(initialDescription);
+    setItems(initialItems.length > 0 ? initialItems : ['', '']);
+  }, [initialTitle, initialDescription, initialItems]);
+
+  const handleAddItem = () => setItems(prev => [...prev, '']);
+
+  const handleItemChange = (index: number, value: string) => {
+    setItems(prev => prev.map((item, i) => (i === index ? value : item)));
+  };
+
+  const handleDeleteItem = (index: number) => {
+    setItems(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const moveItem = (index: number, direction: -1 | 1) => {
+    const newIndex = index + direction;
+
+    if (newIndex < 0 || newIndex >= items.length) {
+      return;
+    }
+
+    setItems(prev => {
+      const copy = [...prev];
+      [copy[index], copy[newIndex]] = [copy[newIndex], copy[index]];
+      return copy;
+    });
+  };
+
+  const placeholderFor = (index: number) => {
+    if (index === 0) return '1st Item';
+    if (index === 1) return '2nd Item';
+    if (index === 2) return '3rd Item';
+    return `${index + 1}th Item`;
+  };
+
+  return (
+    <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, px: 2, position: 'relative', pb: 4 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+        <IconButton onClick={onCancel} aria-label="close">
+          <CloseIcon sx={{ fontSize: 36, fontWeight: 'bold' }} />
+        </IconButton>
+      </Box>
+
+      <Box sx={{ mb: 3 }}>
+        <TextField
+          fullWidth
+          label="Dataset name"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          slotProps={{ input: { 'aria-label': 'dataset name' } }}
+        />
+      </Box>
+
+      <TextField
+        fullWidth
+        label="Description"
+        multiline
+        rows={6}
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        sx={{ mb: 3 }}
+      />
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 3 }}>
+        {items.map((item, index) => (
+          <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography sx={{ width: 24, textAlign: 'right', flexShrink: 0, color: 'text.secondary' }}>
+              {index + 1}
+            </Typography>
+
+            <TextField
+              fullWidth
+              value={item}
+              onChange={(e) => handleItemChange(index, e.target.value)}
+              placeholder={placeholderFor(index)}
+              size="small"
+            />
+
+            <IconButton
+              onClick={() => moveItem(index, -1)}
+              aria-label="move item up"
+              disabled={index === 0}
+            >
+              <ArrowUpwardIcon />
+            </IconButton>
+
+            <IconButton
+              onClick={() => moveItem(index, 1)}
+              aria-label="move item down"
+              disabled={index === items.length - 1}
+            >
+              <ArrowDownwardIcon />
+            </IconButton>
+
+            <IconButton
+              onClick={() => handleDeleteItem(index)}
+              aria-label="delete item"
+              disabled={items.length <= 2}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Box>
+        ))}
+      </Box>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 4 }}>
+        <IconButton onClick={handleAddItem} aria-label="add item">
+          <AddIcon sx={{ fontSize: 52 }} />
+        </IconButton>
+        <Typography variant="body2" align="center">Add new item</Typography>
+      </Box>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={onCancel}
+          disabled={loading}
+          sx={{ flex: 1, py: 1.5 }}
+        >
+          Cancel
+        </Button>
+
+        <Button
+          variant="outlined"
+          onClick={() => onSave({ title, description, items })}
+          disabled={loading}
+          sx={{ flex: 1, py: 1.5 }}
+        >
+          {loading ? 'Saving...' : saveLabel}
+        </Button>
+      </Box>
+
+      {showDelete && onDelete && (
+        <Button
+          variant="outlined"
+          color="error"
+          fullWidth
+          onClick={onDelete}
+          disabled={loading}
+        >
+          Delete Dataset
+        </Button>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
# Create shared dataset form component for add and update pages

## Changes

Refactored the add and update dataset pages to use a shared form component.

### Added

* Added `src/components/DatasetForm.tsx`

  * Shared form UI for both add and update pages
  * Handles dataset title, description, and item editing
  * Supports adding and deleting items
  * Supports moving items up and down to change order
  * Uses conditional props for update-specific behavior

### Updated

#### `src/app/add/page.tsx`

* Replaced duplicated form UI with `DatasetForm`
* Keeps add dataset validation and POST request logic
* Returns to homepage after saving or cancelling

#### `src/app/update/[slug]/page.tsx`

* Replaced duplicated form UI with `DatasetForm`
* Keeps existing dataset fetch/update/delete logic
* Loads existing dataset values into shared form
* Returns to homepage after save, delete, or cancel

## Why

The add and update pages previously contained very similar form interfaces with duplicated UI code.

This change centralizes the shared form logic into a reusable component while still allowing the update page to support additional functionality such as dataset deletion.

## Additional Features

* Added item reordering controls to the shared form
* Added consistent return-to-home behavior using the X or cancel actions
* Added redirect to homepage after saving changes instead of remaining on the puzzle slug page

## Testing

Verified:

* add dataset page still works
* update dataset page still works
* datasets can still be created
* datasets can still be edited
* datasets can still be deleted
* item rows can be reordered
* item rows can be added and removed
* cancel/X buttons return to homepage
* saving changes returns to homepage
* shared form works correctly for both add and update flows