### PR TITLE
Fix authentication linter warnings

### DIFF
--- a/docs/supabase-apply-migrations.md
+++ b/docs/supabase-apply-migrations.md
@@ -1,5 +1,7 @@
 # Apply Migrations
 
+## Local
+
 To apply migrations to your development supabase installation, run the following commands:
 
 ```bash
@@ -9,3 +11,19 @@ npm run db:restart
 ```
 
 This ensures supabase is running, applies migrations, then restarts the supabase instance to apply changes to the supabase config.
+
+## Remote
+
+1. Use the Supabase CLI to login & link the project. You can generate the following command by clicking "CLI setup commands" in the dashboard "Copy" menu (make sure to remove `supabase init` and add `npx` before each command). Alternatively, your project "ref" is the path component after `/project/` in the web URL; you can replace `<your-project-ref>` with it and proceed.
+  - This will prompt you to enter your web browser and login to Supabase; make sure you login to the correct account and follow the CLI instructions.
+
+```bash
+npx supabase login
+npx supabase link --project-ref <your-project-ref>
+```
+
+2. Push unapplied migrations. Answer `Y` if prompted.
+
+```bash
+npx supabase db push
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,13 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [ "error", {
+        "argsIgnorePattern": "^_",
+      } ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -33,8 +33,8 @@ export async function updateSession(request: NextRequest) {
   // with the Supabase client, your users may be randomly logged out.
   const { data } = await supabase.auth.getClaims()
   
-  const user = data?.claims
-
+  // Example of how to use the session to protect a route via proxy middleware.
+  //const user = data?.claims
   // if (
   //   // Require users to be logged in
   //   !user &&

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -31,10 +31,11 @@ export async function updateSession(request: NextRequest) {
 
   // IMPORTANT: If you remove getClaims() and you use server-side rendering
   // with the Supabase client, your users may be randomly logged out.
-  const { data } = await supabase.auth.getClaims()
+  await supabase.auth.getClaims()
   
   // Example of how to use the session to protect a route via proxy middleware.
-  //const user = data?.claims
+  // const { data: data } = await supabase.auth.getClaims() // replace above getClaims() call with this
+  // const user = data?.claims
   // if (
   //   // Require users to be logged in
   //   !user &&


### PR DESCRIPTION
## Overview

This pull request fixes the two linter warnings output by the proxy and server client creation function.

## Changes

- Removed unused variables from `src/lib/proxy.ts`
- Added linting rule for `@typescript-eslint/no-unused-vars` to ignore function arguments that begin with `_`. This is necessary because the culprit function, `setAll,` is passed to a function in the `@supabase/ssr` library. Since the `headers` argument is unneeded in this case, and the function must conform to the library's signature, it is necessary to ignore the unused argument.
- Updated documentation to include explicit instructions for deploying migrations to a hosted Supabase project

Fixes #214 